### PR TITLE
Standardized Appearance + recreated renv.lock - Leshan - 24 Nov 30

### DIFF
--- a/.Rhistory
+++ b/.Rhistory
@@ -1,153 +1,480 @@
-here::i_am("report.Rmd")
-proj_data <- readRDS(
-file = here::here("output/data_clean.rds")
+ifelse(is.na(ICUAdmin),
+NA_character_,
+ifelse(nchar(strsplit(ICUAdmin," ")[[1]][1]) == 8, "%m/%d/%y", "%m/%d/%Y")
 )
-getwd()
-ls
-make report.html
-# Here Command
-here::i_am("code/00_clean_data.R")
-# Reads in Data
-covid_sub_location <- here::here("data/covid_sub.csv")
-covid <- read.csv(covid_sub_location, header = TRUE)
-# Create new variable to indicate if person has COVID-19
-covid <- covid %>%
-mutate(CASE_STATUS = ifelse(CLASIFFICATION_FINAL < 4, 1, 0),
-DIED = ifelse(!is.na(DATE_DIED), 1, 0)
-)
-library(dplyr)
-# Create new variable to indicate if person has COVID-19
-covid <- covid %>%
-mutate(CASE_STATUS = ifelse(CLASIFFICATION_FINAL < 4, 1, 0),
-DIED = ifelse(!is.na(DATE_DIED), 1, 0)
-)
-# Save onto the output folder
-saveRDS(covid, file = here::here("output/data_clean.rds"))
-# Save onto the output folder
-saveRDS(covid, file = here::here("output/data_clean.rds"))
-View(covid)
-library(here)
-library(dplyr)
-here::i_am("code/01_make_tables.R")
-## Create table_nonresp
-## Load the cleaned data
-covid <- readRDS(here::here("output/data_clean.rds"))
-View(covid)
-# Here Command
-here::i_am("code/00_clean_data.R")
-# Reads in Data
-covid_sub_location <- here::here("data/covid_sub.csv")
-covid <- read.csv(covid_sub_location, header = TRUE)
-# Create new variable to indicate if person has COVID-19
-covid <- covid %>%
-mutate(CASE_STATUS = ifelse(CLASIFFICATION_FINAL < 4, 1, 0),
-DIED = ifelse(!is.na(DATE_DIED), 1, 0)
-)
-# Save onto the output folder
-saveRDS(covid, file = here::here("output/data_clean.rds"))
-View(covid)
-table_resp <- covid %>%
-select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
-group_by(CASE_STATUS) %>%
-summarise(
-PNEUMONIA = sum(PNEUMONIA == "Yes"),
-COPD = sum(COPD == "Yes"),
-ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
+),
+CollectionDate = as.Date(substr(CollectionDate, 1, 8),format=ifelse(nchar(strsplit(CollectionDate," ")[[1]][1]) == 8, "%m/%d/%y", "%m/%d/%Y"))
 ) %>%
-as.data.frame()
-## Save the table as an .rds file in the output folder
-saveRDS(table_resp, file = here::here("output/table_resp.rds"))
-View(table_resp)
-table_resp <- covid %>%
-select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
-group_by(CASE_STATUS) %>%
-summarise(
-PNEUMONIA = sum(PNEUMONIA == "Yes", na.rm = TRUE),
-COPD = sum(COPD == "Yes", na.rm = TRUE),
-ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
+# arrange(Name) %>%
+filter(Included == 1) %>%
+select(-Included) %>%
+# filter(n() > 1) %>%
+ungroup() %>%
+ungroup() %>%
+rename()
+paste0("CCI", as.character(1:17))
+df_distinct = df %>%
+distinct(MRN, .keep_all=TRUE)
+df_blood = df %>% filter(SampleType == "BLOOD")
+df_blood_distinct = df_blood %>%
+distinct(MRN, .keep_all = TRUE)
+df_fit =  df %>%
+mutate(time = as.numeric(DiscDate - AdmDate)) %>%
+# mutate(time = DiscDate - AdmDate) %>%
+mutate(TimeToDeath = ifelse(DiscStatus==0, time, NA)) %>%
+# mutate(time_d = ifelse(DiscStatus==0, time, NA)) %>%
+mutate(censor = ifelse(DiscStatus==0, 1, 0)) %>%
+mutate(Race = as.factor(Race)) %>%
+select(MRN,
+time,
+censor,
+# TimeToDisc,
+# TimeToDeath,
+Age,
+Gender,
+Weight,
+BMI,
+Race,
+Pathogenic,
+HIV,
+ImmuSupr,
+AdmTo1stPathoTime,
+PersCandi,
+TPN,
+CVC,
+MV,
+AbdSurgery,
+BurnReqHosp,
+PrevAbx,
+# PrevAntif,
+# AntifType,
+CCI,
+# 47:49,
+64:66,
+38:54) %>%
+distinct(MRN, .keep_all = TRUE) %>%
+rename()
+# df_fit_noNA = df_fit[(!is.na(df_fit$TimeToDeath)),] %>%
+#   filter(complete.cases(.))
+df_fit_noNA = df_fit %>%
+filter(complete.cases(.))
+fit_result = survfit(Surv(time, censor) ~ 1, data=df_fit)
+fit_result
+df_fit
+df_fit_noPatho = df_fit[df_fit$Pathogenic==0,] %>%
+select(c(-Pathogenic,
+-HIV,
+-AdmTo1stPathoTime)) %>%
+rename()
+df_fit_Patho = df_fit[df_fit$Pathogenic==1,] %>%
+select(c(-Pathogenic,
+-HIV,
+-AdmTo1stPathoTime)) %>%
+rename()
+surv_object <- Surv(time = df_fit_Patho$time, event = df_fit_Patho$censor)
+df_fit_Patho$Race = as.factor(df_fit_Patho$Race)
+# 排除TimeToDisc和MRN列，仅使用协变量
+covariates <- df_fit_Patho[, 4:ncol(df_fit_Patho)]
+# 构建Cox比例风险模型
+cox_model <- coxph(surv_object ~ Race, data = covariates)
+# 查看结果
+summary_model = summary(cox_model)
+HR = summary_model$coef[1, "exp(coef)"]
+lowerCI = summary_model$conf.int[1, "lower .95"]
+upperCI = summary_model$conf.int[1, "upper .95"]
+HR = summary_model$coef[1, "Pr(>|z|)"]
+result = data.frame()
+# 构建生存对象
+surv_object <- Surv(time = df_fit_Patho$time, event = df_fit_Patho$censor)
+# 排除不需要的列，仅使用协变量
+covariates <- df_fit_Patho[, 4:ncol(df_fit_Patho)]
+# 初始化结果列表
+results <- lapply(names(covariates), function(var) {
+# 构建单变量Cox模型
+formula <- as.formula(paste("surv_object ~", var))
+cox_model <- coxph(formula, data = df_fit_Patho)
+# 提取所需的统计量
+summary_model <- summary(cox_model)
+HR <- summary_model$coef[1, "exp(coef)"]
+lowerCI <- summary_model$conf.int[1, "lower .95"]
+upperCI <- summary_model$conf.int[1, "upper .95"]
+pvalue <- summary_model$coef[1, "Pr(>|z|)"]
+# 返回数据框
+data.frame(
+Variable = var,
+HR = round(HR,2),
+lowerCI = round(lowerCI,2),
+upperCI = round(upperCI,2),
+pvalue = round(pvalue,4)
 )
-View(table_resp)
-class(table_resp)
-## Create the frequency table table_resp by counting "Yes" responses for each disease of "PNEUMONIA", "COPD", and "ASTHMA"
-table_resp <- covid %>%
-select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
-group_by(CASE_STATUS) %>%
-summarise(
-PNEUMONIA = sum(PNEUMONIA == "Yes", na.rm = TRUE),
-COPD = sum(COPD == "Yes", na.rm = TRUE),
-ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
-) %>%
-as.data.frame()
-class(table_resp)
-''' 1. Leshan: Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)'''
-'''1. Leshan: Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)'''
-'1. Leshan: Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)'
-# Create resp_fig
-## Load the frequency table data
-table_resp = readRDS(here::here("output/table_resp.rds"))
-## Convert CASE_STATUS to a factor for better labeling in the plot
-table_resp$CASE_STATUS = factor(table_resp$CASE_STATUS, labels = c("No COVID-19", "COVID-19"))
-## Reshape data for plotting
-table_resp_long = table_resp %>%
-pivot_longer(cols = -CASE_STATUS, names_to = "Disease", values_to = "Count")
-library(tidyr)
-# Create resp_fig
-## Load the frequency table data
-table_resp = readRDS(here::here("output/table_resp.rds"))
-## Convert CASE_STATUS to a factor for better labeling in the plot
-table_resp$CASE_STATUS = factor(table_resp$CASE_STATUS, labels = c("No COVID-19", "COVID-19"))
-## Reshape data for plotting
-table_resp_long = table_resp %>%
-pivot_longer(cols = -CASE_STATUS, names_to = "Disease", values_to = "Count")
-## Create the grouped bar chart
-resp_fig = ggplot(table_resp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
-geom_bar(stat = "identity", position = position_dodge()) +
-labs(title = "Non-Respiratory Chronic Diseases by COVID-19 Status",
-x = "Non-Respiratory Chronic Disease",
-y = "Count",
-fill = "COVID-19 Status") +
-theme(axis.text.x = element_text(angle = 45, hjust = 1))
+})
+View(df_blood)
+View(df)
+View(df_fit_noPatho)
+knitr::opts_chunk$set(echo = TRUE)
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1)) +
+scale_color_gradient(low = "white", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE)) +
+scale_color_gradient(low = "white", high = "red", name = "Astocyte APOE") +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+simulate <- function(length = 2000, width = 2000, lambda1 = 0.0016, lambda2 = 0.0004, mu1 = 4.18, std1 = 4.06, d = 25, a1 = -0.1, b1 = 2.538, a2 = -0.01, b2=2.162, mu_err = 0, sigma2_err = 0) {
+# 计算A型细胞和B型细胞的数量 - 随机
+num_A <- rpois(1, lambda1 * length * width)
+num_B <- rpois(1, lambda2 * length * width)
+# # 计算A型细胞和B型细胞的数量 - 固定
+# num_A <- lambda1 * length * width
+# num_B <- lambda2 * length * width
+# 生成A型细胞和B型细胞的位置
+df1 <- data.frame(x_pixel = runif(num_A, 0, length), y_pixel = runif(num_A, 0, width))
+df2 <- data.frame(x_pixel = runif(num_B, 0, length), y_pixel = runif(num_B, 0, width))
+# 为A型细胞生成NRN1值
+df1$NRN1 <- log1p(pmax(
+rnorm(num_A, mu1, std1),
+0))
+# df1$NRN1 <- log1p(pmax(
+#   rnorm(num_A, mu1, std1),
+#   0))
+# 寻找每个B型细胞最近的A型细胞
+nearest <- sapply(1:nrow(df2), function(i) {
+distances <- sqrt((df2$x_pixel[i] - df1$x_pixel)^2 + (df2$y_pixel[i] - df1$y_pixel)^2)
+which.min(distances)
+})
+df2$NN_ID <- nearest
+df2$NN_x <- df1$x_pixel[nearest]
+df2$NN_y <- df1$y_pixel[nearest]
+df2$NN_NRN1 <- df1$NRN1[nearest]
+# 计算NN_distance
+df2$NN_distance <- sqrt((df2$x_pixel - df2$NN_x)^2 + (df2$y_pixel - df2$NN_y)^2)
+# 生成epsilon值
+if (sigma2_err == 0) {
+df2$epsilon <- rep(mu_err, nrow(df2))
+} else {
+df2$epsilon <- rnorm(nrow(df2), mu_err, sqrt(sigma2_err))
+}
+# # 计算b2 - both 方案12适用
+# b2 <- d * (a1 - a2) + b1
+# # # 计算APOE值 - 方案1: NRN1 = a* APOE + b + error
+# # df2$APOE <- ifelse(df2$NN_distance < d,
+# #                    (df2$NN_NRN1 - b1 - df2$epsilon) / a1,
+# #                    (df2$NN_NRN1 - df2$epsilon - b2) / a2)
+# 计算APOE值 - 方案2: APOE = A * NRN1 + b + error
+# df2$APOE <- ifelse(df2$NN_distance < d,
+#                    df2$NN_NRN1 * a1 + b1 + df2$epsilon,
+#                    df2$NN_NRN1 * a2 + b2 + df2$epsilon)
+# 计算APOE值 - 方案3: APOE ~ N(mu2, std2)
+# 计算APOE值 - 方案4: APOE ~ N(mu2, std2) - 简单版本
+a = 2
+b = 1.2
+# mu_NRN1 = mean(df1$NRN1)
+# df2$mu21 = a * mu_NRN1 + b
+df2$mu21 = a * df2$NN_NRN1 + b
+df2$std21 = 0.1
+df2$mu22 = b
+# df2$std22 = 1.83
+df2$std22 = 1
+df2$APOE <- mapply(function(NN_distance, mu21, mu22, std21, std22) {
+if (NN_distance < d) {
+return(rnorm(1, mu21, std21))  # 为每行生成一个随机数
+} else {
+return(sample(c(rnorm(1, mu22, std22), 0), 1))  # 为每行生成一个随机数
+}
+}, df2$NN_distance, df2$mu21, df2$mu22, df2$std21, df2$std22)
+# 计算APOE值 - 去负值
+df2$APOE <- pmax(0, df2$APOE)
+# 返回两个dataframe
+return(list(df1 = df1, df2 = df2))
+}
+# 运行模拟
+results <- simulate(length = 2000,
+width = 2000,
+lambda1 = 0.0004,
+lambda2 = 0.0001,
+mu1 = 4.18,
+std1 = 4.06,
+d = 25,
+a1 = 0.1,
+b1 = 1.70,
+a2 = 0.01,
+b2=2.07,
+mu_err = 0.1,
+sigma2_err = 0.01)
+df1 <- results$df1
+df2 <- results$df2
+# 使用基础R的hist()绘制直方图
+hist(df1$NRN1, breaks=50, main="Distribution of NRN1",
+xlab="NRN1 Values", col="skyblue", border="black")
+# 使用基础R的hist()绘制直方图
+hist(expm1(df1$NRN1), breaks=50, main="Distribution of NRN1",
+xlab="NRN1 Values", col="skyblue", border="black")
 library(ggplot2)
-# Create resp_fig
-## Load the frequency table data
-table_resp = readRDS(here::here("output/table_resp.rds"))
-## Convert CASE_STATUS to a factor for better labeling in the plot
-table_resp$CASE_STATUS = factor(table_resp$CASE_STATUS, labels = c("No COVID-19", "COVID-19"))
-## Reshape data for plotting
-table_resp_long = table_resp %>%
-pivot_longer(cols = -CASE_STATUS, names_to = "Disease", values_to = "Count")
-## Create the grouped bar chart
-resp_fig = ggplot(table_resp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
-geom_bar(stat = "identity", position = position_dodge()) +
-labs(title = "Non-Respiratory Chronic Diseases by COVID-19 Status",
-x = "Non-Respiratory Chronic Disease",
-y = "Count",
-fill = "COVID-19 Status") +
-theme(axis.text.x = element_text(angle = 45, hjust = 1))
-## Save the plot as a .png file in the output folder
-ggsave(filename = here::here("output/resp_fig.png"), plot = resp_fig, width = 8, height = 6)
-table_nonresp <- readRDS(here::here("output/table_nonresp.rds"))
-## Convert CASE_STATUS to a factor for better labeling in the plot
-table_nonresp$CASE_STATUS <- factor(table_nonresp$CASE_STATUS, labels = c("No COVID-19", "COVID-19"))
-## Reshape data for plotting
-table_nonresp_long <- table_nonresp %>%
-pivot_longer(cols = -CASE_STATUS, names_to = "Disease", values_to = "Count")
-## Create the grouped bar chart
-nonresp_fig <- ggplot(table_nonresp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
-geom_bar(stat = "identity", position = position_dodge()) +
-labs(title = "Non-Respiratory Chronic Diseases by COVID-19 Status",
-x = "Non-Respiratory Chronic Disease",
-y = "Count",
-fill = "COVID-19 Status") +
-theme_minimal() +
-theme(axis.text.x = element_text(angle = 45, hjust = 1))
-## Save the plot as a .png file in the output folder
-ggsave(filename = here::here("output/nonresp_fig.png"), plot = nonresp_fig, width = 8, height = 6)
-View(table_nonresp)
-View(table_resp)
-## Load the cleaned data
-covid <- readRDS(here::here("output/data_clean.rds"))
-## 1. Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)
+ggplot(df1, aes(x=NRN1)) +
+geom_histogram(bins=50, fill="skyblue", color="black") +
+labs(title="Distribution of NRN1", x="NRN1 Values", y="Count")
+ggplot(expm1(df1), aes(x=NRN1)) +
+geom_histogram(bins=50, fill="skyblue", color="black") +
+labs(title="Distribution of NRN1", x="NRN1 Values", y="Count")
+library(ggplot2)
+ggplot(df2, aes(x=NN_distance)) +
+geom_histogram(bins=50, fill="skyblue", color="black") +
+labs(title="Distribution of distance", x="Distance from an Astrocyte to Nearest Neuron Values", y="Count")
+library(ggplot2)
+ggplot(expm1(df2), aes(x=APOE)) +
+geom_histogram(bins=50, fill="skyblue", color="black") +
+labs(title="Distribution of exp(GPX4)-1", x="GPX4 Values", y="Count")
+ggplot(df2, aes(x=APOE)) +
+geom_histogram(bins=50, fill="skyblue", color="black") +
+labs(title="Simulated Distribution of Apoe", x="Apoe Values", y="Count")
+# 如果尚未安装，请先安装所需的包
+# install.packages("ggplot2")
+# install.packages("ggnewscale")
+# 加载必要的库
+library(ggplot2)
+library(ggnewscale)
+# 假设您的数据框是 df1 和 df2
+# 使用 ggplot2 开始绘图
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1)) +
+scale_color_gradient(low = "white", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE)) +
+scale_color_gradient(low = "white", high = "red", name = "Astocyte APOE") +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1)) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+# 假设您的数据框是 df1 和 df2
+# 使用 ggplot2 开始绘图
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1080, 1130), ylim = c(200, 400)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1700, 1900), ylim = c(400, 500)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1800, 1900), ylim = c(400, 500)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1850, 1950), ylim = c(400, 500)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1850, 1950), ylim = c(400, 600)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1850, 1950), ylim = c(400, 530)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(1850, 1930), ylim = c(400, 530)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), size=20) +
+scale_color_gradient(low = "white", high = "forestgreen", name = "Astocyte APOE") +
+# 添加新的填充刻度
+new_scale_fill() +
+# 绘制 df1 的点，添加极细的轮廓
+geom_point(
+data = df1,
+aes(x = x_pixel, y = y_pixel, fill = NRN1),
+shape = 21,       # 使用有边框和填充的圆形
+color = "lightgrey",  # 边框颜色
+stroke = 0.01,      # 边框粗细
+size=20
+) +
+scale_fill_gradient(low = "white", high = "red", name = "Neuron NRN1") +
+coord_cartesian(xlim = c(700, 800), ylim = c(100, 200)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X", y = "Y") +
+# 美化主题（可选）
+theme_minimal()
+1080
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(700, 800), ylim = c(100, 200)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(700, 800), ylim = c(80, 160)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+ggplot() +
+# 绘制 df1 的点，并根据 NRN1 进行着色，从白色到红色
+geom_point(data = df1, aes(x = x_pixel, y = y_pixel, color = NRN1), size=20) +
+scale_color_gradient(low = "lightgrey", high = "forestgreen", name = "Neuron NRN1") +
+# 添加新的颜色刻度
+new_scale_color() +
+# 绘制 df2 的点，并根据 APOE 进行着色，从白色到绿色
+geom_point(data = df2, aes(x = x_pixel, y = y_pixel, color = APOE), shape=17, size=20) +
+scale_color_gradient(low = "lightgrey", high = "magenta", name = "Astocyte APOE") +
+coord_cartesian(xlim = c(680, 790), ylim = c(80, 160)) +
+# 添加标题和标签（可选）
+labs(title = "Spatial Distribution of Simulated Neurons and Astrocytes", x = "X (um)", y = "Y (um)") +
+# 美化主题（可选）
+theme_minimal()
+getwd()
+setwd("D:/zls/Emory/Courses/2024 Fall/DATA 550/Assignments/MidtermProject/data550midterm")
+renv::restore()
+renv::restore()
+renv::restore()
+renv::status()
+source("env/activate.R")
+getwd()
+source("renv/activate.R")
+renv::rstore()
+renv::restore()
+renv::restore()
+setwd("D:/zls/Emory/Courses/2024 Fall/DATA 550/Assignments/MidtermProject/data550midterm")
+renv::deactivate()
+.libPaths()
+installed.packages()
+if ("Rcpp" %in% rownames(installed.packages())) {
+print("Rcpp 已安装")
+} else {
+print("Rcpp 未安装")
+}
+install.packages("Rcpp")
+.libPaths()
+source('renv/activate.R')
+renv::cache.clean()
+renv::deactivate()
+rownames(installed.packages())
+installed.packages()["Rcpp", "Version"]
+source('renv/activate.R')
+renv::restore()
+renv::restore()
+renv::restore()
+renv::restore()
+renv::restore()
+renv::restore()
+renv::restore()
+renv::restore()
+renv::snapshot()
+.libPaths()
+install.packages("yaml")
+renv::snapshot()
+here::i_am("code/01_make_tables.R")
+# Frequency of demographic variables (AGE, SEX, CASE_STATUS)---------------------------------------------------------------------
+table_resp =
+# Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)---------------------------------------------------------------------
 table_resp <- covid %>%
 select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
 group_by(CASE_STATUS) %>%
@@ -156,123 +483,30 @@ PNEUMONIA = sum(PNEUMONIA == "Yes", na.rm = TRUE),
 COPD = sum(COPD == "Yes", na.rm = TRUE),
 ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
 )
-## Save the table to output/table_resp.rds
-saveRDS(table_resp, file = here::here("output/table_resp.rds"))
-View(table_resp)
-# Create resp_fig
-## Load the frequency table data
-table_resp = readRDS(here::here("output/table_resp.rds"))
-## Convert CASE_STATUS to a factor for better labeling in the plot
-table_resp$CASE_STATUS = factor(table_resp$CASE_STATUS, labels = c("No COVID-19", "COVID-19"))
-## Reshape data for plotting
-table_resp_long = table_resp %>%
-pivot_longer(cols = -CASE_STATUS, names_to = "Disease", values_to = "Count")
-## Create the grouped bar chart
-resp_fig = ggplot(table_resp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
-geom_bar(stat = "identity", position = position_dodge()) +
-labs(title = "Non-Respiratory Chronic Diseases by COVID-19 Status",
-x = "Non-Respiratory Chronic Disease",
-y = "Count",
-fill = "COVID-19 Status") +
-theme(axis.text.x = element_text(angle = 45, hjust = 1))
-## Save the plot as a .png file in the output folder
-ggsave(filename = here::here("output/resp_fig.png"), plot = resp_fig, width = 8, height = 6)
-resp_fig
-knitr::table_nonresp
-knitr::kable(table_nonresp)
-knitr::kable(table_nonresp, title="hi")
-knitr::kable(table_nonresp, main="hi")
-knitr::kable(table_nonresp, caption="Frequencies of Respiratory Diseases Cases by Covid-19 Status")
-saveRDS(resp_fig, file = here::here("output/resp_fig.rds"))
-rm(resp_fig)
-resp_fig = readRDS(file = here::here("output/resp_fig.rds"))
-resp_fig
-## Create the grouped bar chart
-resp_fig = ggplot(table_resp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
-geom_bar(stat = "identity", position = position_dodge()) +
-labs(title = "Number of Respiratory Disease Cases by COVID-19 Status",
-x = "Respiratory Disease",
-y = "Count",
-fill = "COVID-19 Status") +
-theme(axis.text.x = element_text(angle = 45, hjust = 1))
-saveRDS(resp_fig, file = here::here("output/resp_fig.rds"))
-resp_fig = readRDS(file = here::here("output/resp_fig.rds"))
-resp_fig
-## Save the plot as a .png file in the output folder
-ggsave(filename = here::here("output/resp_fig.png"), plot = resp_fig, width = 8, height = 6)
-#| fig.align = "center",
-#| out.width = "600px"
-knitr::include_graphics(
-here::here("output/nonresp_fig.png")
-)
-knitr::include_graphics(
-here::here("output/resp_fig.rds")
-)
-knitr::include_graphics(
-here::here("output/resp_fig.rds")
-)
-knitr::include_graphics(
-resp_fig)
-resp_fig = readRDS(file = here::here("output/resp_fig.rds"))
-resp_fig
-knitr::include_graphics(
-resp_fig)
-knitr::kable(
-resp_fig)
-knitr::table(
-resp_fig)
-knitr::kable(
-resp_fig)
-pic
-knitr::include_graphics(
-here::here("output/nonresp_fig.png")
-)
-#| fig.align = "center",
-#| out.width = "600px"
-knitr::include_graphics(
-here::here("output/resp_fig.png")
-)
-table_resp <- readRDS(
-file = here::here("output/table_resp.rds")
-)
-table_resp <- readRDS(
-file = here::here("output/table_resp.rds")
-)
-knitr::kable(table_resp, caption="Frequencies of Respiratory Diseases Cases by Covid-19 Status")
-# Show Figure
-#| fig.align = "center",
-#| out.width = "600px"
-knitr::include_graphics(
-here::here("output/resp_fig.png")
-)
-here::i_am("report.Rmd")
-proj_data <- readRDS(
-file = here::here("output/data_clean.rds")
-)
-rm(list=ls())
-# Here Command
-here::i_am("code/00_clean_data.R")
-# Reads in Data
-covid_sub_location <- here::here("data/covid_sub.csv")
-covid <- read.csv(covid_sub_location, header = TRUE)
-# Create new variable to indicate if person has COVID-19
-covid <- covid %>%
-mutate(CASE_STATUS = ifelse(CLASIFFICATION_FINAL < 4, 1, 0),
-DIED = ifelse(!is.na(DATE_DIED), 1, 0)
-)
-# Here Command
-here::i_am("code/00_clean_data.R")
-library(dplyr)
-# Create new variable to indicate if person has COVID-19
-covid <- covid %>%
-mutate(CASE_STATUS = ifelse(CLASIFFICATION_FINAL < 4, 1, 0),
-DIED = ifelse(!is.na(DATE_DIED), 1, 0)
-)
-# Save onto the output folder
-saveRDS(covid, file = here::here("output/data_clean.rds"))
-source("D:/zls/Emory/Courses/2024 Fall/DATA 550/Assignments/FinalProject/data550midterm/code/00_clean_data.R", echo=TRUE)
-detach("packages:here")
 library(here)
-detach("packages:here")
-detach("package:here")
-detach("dplyr")
+library(dplyr)
+table_resp <- covid %>%
+select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
+group_by(CASE_STATUS) %>%
+summarise(
+PNEUMONIA = sum(PNEUMONIA == "Yes", na.rm = TRUE),
+COPD = sum(COPD == "Yes", na.rm = TRUE),
+ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
+)
+# Load the cleaned data
+covid <- readRDS(here::here("output/data_clean.rds"))
+table_resp <- covid %>%
+select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
+group_by(CASE_STATUS) %>%
+summarise(
+PNEUMONIA = sum(PNEUMONIA == "Yes", na.rm = TRUE),
+COPD = sum(COPD == "Yes", na.rm = TRUE),
+ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
+)
+class(table_resp)
+# Frequency of demographic variables (AGE, SEX, CASE_STATUS)---------------------------------------------------------------------
+table_resp = data.frame()
+# Frequency of demographic variables (AGE, SEX, CASE_STATUS)---------------------------------------------------------------------
+table_demog = data.frame()
+# Frequency of demographic variables (AGE, SEX, CASE_STATUS)---------------------------------------------------------------------
+table_demographics = data.frame()

--- a/.Rprofile
+++ b/.Rprofile
@@ -1,1 +1,0 @@
-source("renv/activate.R")

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ report.html: code/03_render_report.R \
 output/data_clean.rds: code/00_clean_data.R data/covid_sub.csv 
 	Rscript code/00_clean_data.R
 	
-tables: output/table_nonresp.rds output/table_resp.rds output/table_severity.rds
-output/table_nonresp.rds output/table_resp.rds output/table_severity.rds: code/01_make_tables.R output/data_clean.rds
+tables: output/table_demographics.rds output/table_nonresp.rds output/table_resp.rds output/table_severity.rds
+output/table_demographics.rds output/table_nonresp.rds output/table_resp.rds output/table_severity.rds: code/01_make_tables.R output/data_clean.rds
 	Rscript code/01_make_tables.R 
 
 figures: output/nonresp_fig.png output/resp_fig.png output/severity_fig.png

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 The data for this project contains clinical and demographic information on COVID-19 cases in Mexico. We aim to conduct a descriptive analysis on different demographic and clinical factors of disease. The `data/` folder contains the raw data and a data dictionary. 
 
 ------------------------------------------------------------------------
+## How to Use
+1. Using R Console, set the project root directory as the working directory.
+  - Run `source('renv/activate.R')`
+  - Run `renv::restore()`
+2. Using terminal, go to the project root directory.
+  - run `make` or `make report.html` to make the report.
+
+------------------------------------------------------------------------
 
 ## Code Structure
 

--- a/code/01_make_tables.R
+++ b/code/01_make_tables.R
@@ -7,9 +7,17 @@ here::i_am("code/01_make_tables.R")
 covid <- readRDS(here::here("output/data_clean.rds"))
 
 # Frequency of demographic variables (AGE, SEX, CASE_STATUS)---------------------------------------------------------------------
+table_demographics = data.frame(c("DemoGraphics-ToBeFilled"))
+# remember to rename variables to remove "_" in te variable names, e.g., rename("Covid Status"=CASE_STATUS)
 
 
-# Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)---------------------------------------------------------------------
+
+
+## Save the table to output/table_demographics.rds
+saveRDS(table_demographics, file = here::here("output/table_demographics.rds"))
+
+
+# Frequency of respiratory diseases (PNEUMONIA, COPD, and ASTHMA)----------------------------------------------------------------
 table_resp <- covid %>%
   select(CASE_STATUS, PNEUMONIA, COPD, ASTHMA) %>%
   group_by(CASE_STATUS) %>%
@@ -17,14 +25,16 @@ table_resp <- covid %>%
     PNEUMONIA = sum(PNEUMONIA == "Yes", na.rm = TRUE),
     COPD = sum(COPD == "Yes", na.rm = TRUE),
     ASTHMA = sum(ASTHMA == "Yes", na.rm = TRUE),
-  )
+  ) %>%
+  as.data.frame() %>%
+  rename("Covid Status"=CASE_STATUS)
 
 
 ## Save the table to output/table_resp.rds
 saveRDS(table_resp, file = here::here("output/table_resp.rds"))
 
 
-# Frequency of non-respiratory diseases (DIABETES, CARDIOVASCULAR, OBESITY, RENAL_CHRONIC, HYPERTENSION)---------------------------------------------------------------------
+# Frequency of non-respiratory diseases (DIABETES, CARDIOVASCULAR, OBESITY, RENAL_CHRONIC, HYPERTENSION)-------------------------
 table_nonresp <- covid %>%
   select(CASE_STATUS, DIABETES, CARDIOVASCULAR, OBESITY, RENAL_CHRONIC, HIPERTENSION) %>%
   group_by(CASE_STATUS) %>%
@@ -35,12 +45,16 @@ table_nonresp <- covid %>%
     RENAL_CHRONIC = sum(RENAL_CHRONIC == "Yes", na.rm = TRUE),
     HIPERTENSION = sum(HIPERTENSION == "Yes", na.rm = TRUE)
   ) %>%
-  as.data.frame()
+  as.data.frame() %>%
+  rename("Covid Status"=CASE_STATUS,
+         "CHRONIC RENAL"=RENAL_CHRONIC)
 
-## Save the table as an .rds file in the output folder
+## Save the table to output/table_nonresp.rds
 saveRDS(table_nonresp, file = here::here("output/table_nonresp.rds"))
 
-# Frequency of severity variables (ICU, INTUBED, DIED)---------------------------------------------------------------------
+
+
+# Frequency of severity variables (ICU, INTUBED, DIED)----------------------------------------------------------------------------
 table_severity <- covid %>%
   select(CASE_STATUS, ICU, INTUBED, DIED) %>%
   group_by(CASE_STATUS) %>%
@@ -49,9 +63,10 @@ table_severity <- covid %>%
     INTUBED = sum(INTUBED == "Yes", na.rm = TRUE),
     DIED = sum(DIED == 1, na.rm = TRUE),
   ) %>%
-  as.data.frame()
+  as.data.frame() %>%
+  rename("Covid Status"=CASE_STATUS)
 
-## Save the table as an .rds file in the output folder
+## Save the table to output/table_severity.rds
 saveRDS(table_severity, file = here::here("output/table_severity.rds"))
 
 

--- a/code/02_make_figures.R
+++ b/code/02_make_figures.R
@@ -5,7 +5,7 @@ library(tidyr)
 here::i_am("code/02_make_figures.R")
 
 
-# 1. Leshan - Create resp_fig
+# 1. Leshan - Create resp_fig ==============================================================================
 ## Load the frequency table data
 table_resp = readRDS(here::here("output/table_resp.rds"))
 
@@ -19,7 +19,7 @@ table_resp_long = table_resp %>%
 ## Create the grouped bar chart
 resp_fig = ggplot(table_resp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
   geom_bar(stat = "identity", position = position_dodge()) +
-  labs(title = "Number of Respiratory Disease Cases by COVID-19 Status",
+  labs(title = "Number of Respiratory Chronic Disease Cases by COVID-19 Status",
        x = "Respiratory Disease",
        y = "Count",
        fill = "COVID-19 Status") +
@@ -29,7 +29,7 @@ resp_fig = ggplot(table_resp_long, aes(x = Disease, y = Count, fill = CASE_STATU
 ggsave(filename = here::here("output/resp_fig.png"), plot = resp_fig, width = 8, height = 6)
 
 
-# Create nonresp_fig
+# Ziyi - Create nonresp_fig ================================================================================
 ## Load the frequency table data
 table_nonresp <- readRDS(here::here("output/table_nonresp.rds"))
 
@@ -43,18 +43,17 @@ table_nonresp_long <- table_nonresp %>%
 ## Create the grouped bar chart
 nonresp_fig <- ggplot(table_nonresp_long, aes(x = Disease, y = Count, fill = CASE_STATUS)) +
   geom_bar(stat = "identity", position = position_dodge()) +
-  labs(title = "Non-Respiratory Chronic Diseases by COVID-19 Status",
+  labs(title = "Number of Non-Respiratory Chronic Diseases by COVID-19 Status",
        x = "Non-Respiratory Chronic Disease",
        y = "Count",
        fill = "COVID-19 Status") +
-  theme_minimal() +
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
 ## Save the plot as a .png file in the output folder
 ggsave(filename = here::here("output/nonresp_fig.png"), plot = nonresp_fig, width = 8, height = 6)
 
 
-# Create severity_fig
+# Menglong - Create severity_fig ===========================================================================
 ## Load the frequency table data
 table_severity <- readRDS(here::here("output/table_severity.rds"))
 
@@ -69,12 +68,11 @@ table_severity_long <- table_severity %>%
 severity_fig <- ggplot(table_severity_long, aes(x = Type, y = Count, fill = CASE_STATUS)) +
   geom_bar(stat = "identity", position = position_dodge()) +
   labs(
-    title = "Severity Frequency by COVID-19 Status",
-    x = "COVID-19 Status",
-    y = "Frequency",
-    fill = "Severity Type"
+    title = "Number of Disease Severity Cases by COVID-19 Status",
+    x = "Severity Type",
+    y = "Count",
+    fill = "COVID-19 Status"
   ) +
-  theme_minimal()+
   theme(axis.text.x = element_text(angle = 45, hjust = 1))
 
 ## Save the figure as a severity_fig.png file in the output folder

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.1",
+    "Version": "4.4.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -11,7 +11,7 @@
   "Packages": {
     "MASS": {
       "Package": "MASS",
-      "Version": "7.3-60.0.1",
+      "Version": "7.3-60.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -22,11 +22,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "b765b28387acc8ec9e9c1530713cb19c"
+      "Hash": "2f342c46163b0b54d7b64d1f798e2c78"
     },
     "Matrix": {
       "Package": "Matrix",
-      "Version": "1.6-5",
+      "Version": "1.7-0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -39,13 +39,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "8c7115cd3a0e048bda2a7cd110549f7a"
+      "Hash": "1920b2f11133b12350024297d8a4ff4a"
     },
     "R6": {
       "Package": "R6",
       "Version": "2.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -55,28 +55,17 @@
       "Package": "RColorBrewer",
       "Version": "1.1-3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
       "Hash": "45f0398006e83a5b10b72a90663d8d8c"
     },
-    "Rcpp": {
-      "Package": "Rcpp",
-      "Version": "1.0.11",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "methods",
-        "utils"
-      ],
-      "Hash": "ae6cbbe1492f4de79c45fce06f967ce8"
-    },
     "base64enc": {
       "Package": "base64enc",
       "Version": "0.1-3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -84,13 +73,14 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.6.1",
+      "Version": "0.8.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "base64enc",
         "cachem",
+        "fastmap",
         "grDevices",
         "htmltools",
         "jquerylib",
@@ -101,24 +91,24 @@
         "rlang",
         "sass"
       ],
-      "Hash": "c0d8599494bc7fb408cd206bbdd9cab0"
+      "Hash": "b299c6741ca9746fb227debcb0f9fb6c"
     },
     "cachem": {
       "Package": "cachem",
-      "Version": "1.0.8",
+      "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "fastmap",
         "rlang"
       ],
-      "Hash": "c35768291560ce302c0a6589f92e837d"
+      "Hash": "cd9a672193789068eb5a2aad65a0dedf"
     },
     "cli": {
       "Package": "cli",
       "Version": "3.6.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
@@ -127,9 +117,9 @@
     },
     "colorspace": {
       "Package": "colorspace",
-      "Version": "2.1-0",
+      "Version": "2.1-1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "grDevices",
@@ -137,53 +127,34 @@
         "methods",
         "stats"
       ],
-      "Hash": "f20c47fd52fae58b4e377c37bb8c335b"
-    },
-    "commonmark": {
-      "Package": "commonmark",
-      "Version": "1.9.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Hash": "14eb0596f987c71535d07c3aff814742"
+      "Hash": "d954cb1c57e8d8b756165d7ba18aa55a"
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.7",
+      "Version": "0.5.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "5a295d7d963cc5035284dcdbaf334f4e"
-    },
-    "crayon": {
-      "Package": "crayon",
-      "Version": "1.5.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "grDevices",
-        "methods",
-        "utils"
-      ],
-      "Hash": "e8a1e41acf02548751f45c718d55aa6a"
+      "Hash": "91570bba75d0c9d3f1040c835cee8fba"
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.33",
+      "Version": "0.6.37",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "b18a9cf3c003977b0cc49d5e76ebe48d"
+      "Hash": "33698c4b3127fc9f506654607fb73676"
     },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.1.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "R6",
@@ -202,33 +173,21 @@
       ],
       "Hash": "fedd9d00c2944ff00a0e2696ccf048ec"
     },
-    "ellipsis": {
-      "Package": "ellipsis",
-      "Version": "0.3.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "rlang"
-      ],
-      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
-    },
     "evaluate": {
       "Package": "evaluate",
-      "Version": "0.23",
+      "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
-        "R",
-        "methods"
+        "R"
       ],
-      "Hash": "daf4a1246be12c1fa8c7705a0935c1a0"
+      "Hash": "3fd29944b231036ad67c3edb32e02201"
     },
     "fansi": {
       "Package": "fansi",
       "Version": "1.0.6",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "grDevices",
@@ -238,46 +197,46 @@
     },
     "farver": {
       "Package": "farver",
-      "Version": "2.1.1",
+      "Version": "2.1.2",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "8106d78941f34855c440ddb946b8f7a5"
+      "Repository": "CRAN",
+      "Hash": "680887028577f3fa2a81e410ed0d6e42"
     },
     "fastmap": {
       "Package": "fastmap",
-      "Version": "1.1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "f7736a18de97dea803bde0a2daaafb27"
+      "Repository": "CRAN",
+      "Hash": "aa5e1cd11c2d15497494c5292d7ffcc8"
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.2",
+      "Version": "0.5.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "htmltools",
         "rlang"
       ],
-      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
+      "Hash": "bd1297f9b5b1fc1372d19e2c4cd82215"
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.6.3",
+      "Version": "1.6.5",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
+      "Hash": "7f48af39fa27711ea5fbd183b399920d"
     },
     "generics": {
       "Package": "generics",
       "Version": "0.1.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
@@ -286,9 +245,9 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.4",
+      "Version": "3.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "MASS",
         "R",
@@ -307,39 +266,40 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "313d31eff2274ecf4c1d3581db7241f9"
+      "Hash": "44c6a2f8202d5b7e878ea274b1092426"
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.7.0",
+      "Version": "1.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "e0b3a53876554bd45879e596cdb10a52"
+      "Hash": "5899f1eaa825580172bb56c08266f37c"
     },
     "gtable": {
       "Package": "gtable",
-      "Version": "0.3.4",
+      "Version": "0.3.6",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
         "glue",
         "grid",
         "lifecycle",
-        "rlang"
+        "rlang",
+        "stats"
       ],
-      "Hash": "b29cf3031f49b04ab9c852c912547eef"
+      "Hash": "de949855009e2d4d0e52a844e30617ae"
     },
     "here": {
       "Package": "here",
       "Version": "1.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "rprojroot"
       ],
@@ -347,52 +307,36 @@
     },
     "highr": {
       "Package": "highr",
-      "Version": "0.10",
+      "Version": "0.11",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "xfun"
       ],
-      "Hash": "06230136b2d2b9ba5805e1963fa6e890"
+      "Hash": "d65ba49117ca223614f71b60d85b8ab7"
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.7",
+      "Version": "0.5.8.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "base64enc",
         "digest",
-        "ellipsis",
         "fastmap",
         "grDevices",
         "rlang",
         "utils"
       ],
-      "Hash": "2d7b3857980e0e0d0a1fd6f11928ab0f"
-    },
-    "httpuv": {
-      "Package": "httpuv",
-      "Version": "1.6.13",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "Rcpp",
-        "later",
-        "promises",
-        "utils"
-      ],
-      "Hash": "d23d2879001f3d82ee9dc38a9ef53c4c"
+      "Hash": "81d371a9cc60640e74e4ab6ac46dcedc"
     },
     "isoband": {
       "Package": "isoband",
       "Version": "0.2.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "grid",
         "utils"
@@ -403,7 +347,7 @@
       "Package": "jquerylib",
       "Version": "0.1.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "htmltools"
       ],
@@ -411,19 +355,19 @@
     },
     "jsonlite": {
       "Package": "jsonlite",
-      "Version": "1.8.8",
+      "Version": "1.8.9",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "methods"
       ],
-      "Hash": "e1b9c55281c5adc4dd113652d9e26768"
+      "Hash": "4e993b65c2c3ffbffce7bb3e2c6f832b"
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.45",
+      "Version": "1.49",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "evaluate",
@@ -433,29 +377,18 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "1ec462871063897135c1bcbe0fc8f07d"
+      "Hash": "9fcb189926d93c636dea94fbe4f44480"
     },
     "labeling": {
       "Package": "labeling",
       "Version": "0.4.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "graphics",
         "stats"
       ],
       "Hash": "b64ec208ac5bc1852b285f665d6368b3"
-    },
-    "later": {
-      "Package": "later",
-      "Version": "1.3.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "Rcpp",
-        "rlang"
-      ],
-      "Hash": "a3e051d405326b8b0012377434c62b37"
     },
     "lattice": {
       "Package": "lattice",
@@ -476,7 +409,7 @@
       "Package": "lifecycle",
       "Version": "1.0.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -489,7 +422,7 @@
       "Package": "magrittr",
       "Version": "2.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -499,7 +432,7 @@
       "Package": "memoise",
       "Version": "2.0.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "cachem",
         "rlang"
@@ -527,7 +460,7 @@
       "Package": "mime",
       "Version": "0.12",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "tools"
       ],
@@ -535,18 +468,18 @@
     },
     "munsell": {
       "Package": "munsell",
-      "Version": "0.5.0",
+      "Version": "0.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "colorspace",
         "methods"
       ],
-      "Hash": "6dfe8bf774944bd5595785e3229d8771"
+      "Hash": "4fd8900853b746af55b81fda99da7695"
     },
     "nlme": {
       "Package": "nlme",
-      "Version": "3.1-166",
+      "Version": "3.1-164",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -556,13 +489,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "ccbb8846be320b627e6aa2b4616a2ded"
+      "Hash": "a623a2239e642806158bc4dc3f51565d"
     },
     "pillar": {
       "Package": "pillar",
       "Version": "1.9.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "cli",
         "fansi",
@@ -579,33 +512,17 @@
       "Package": "pkgconfig",
       "Version": "2.0.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
-    "promises": {
-      "Package": "promises",
-      "Version": "1.2.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R6",
-        "Rcpp",
-        "fastmap",
-        "later",
-        "magrittr",
-        "rlang",
-        "stats"
-      ],
-      "Hash": "0d8a15c9d000970ada1ab21405387dee"
-    },
     "purrr": {
       "Package": "purrr",
       "Version": "1.0.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -620,7 +537,7 @@
       "Package": "rappdirs",
       "Version": "0.3.3",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -628,30 +545,30 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.3",
+      "Version": "1.0.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "41b847654f567341725473431dd0d5ab"
+      "Hash": "397b7b2a265bc5a7a06852524dabae20"
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.1.3",
+      "Version": "1.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "42548638fae05fd9a9b5f3f437fbbbe2"
+      "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.25",
+      "Version": "2.29",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "bslib",
@@ -662,20 +579,19 @@
         "jsonlite",
         "knitr",
         "methods",
-        "stringr",
         "tinytex",
         "tools",
         "utils",
         "xfun",
         "yaml"
       ],
-      "Hash": "d65e35823c817f09f4de424fcdfa812a"
+      "Hash": "df99277f63d01c34e95e3d2f06a79736"
     },
     "rprojroot": {
       "Package": "rprojroot",
       "Version": "2.0.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -683,9 +599,9 @@
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.8",
+      "Version": "0.4.9",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R6",
         "fs",
@@ -693,13 +609,13 @@
         "rappdirs",
         "rlang"
       ],
-      "Hash": "168f9353c76d4c4b0a0bbf72e2c2d035"
+      "Hash": "d53dbfddf695303ea4ad66f86e99b95d"
     },
     "scales": {
       "Package": "scales",
       "Version": "1.3.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "R6",
@@ -715,67 +631,24 @@
       ],
       "Hash": "c19df082ba346b0ffa6f833e92de34d1"
     },
-    "shiny": {
-      "Package": "shiny",
-      "Version": "1.9.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "bslib",
-        "cachem",
-        "commonmark",
-        "crayon",
-        "fastmap",
-        "fontawesome",
-        "glue",
-        "grDevices",
-        "htmltools",
-        "httpuv",
-        "jsonlite",
-        "later",
-        "lifecycle",
-        "methods",
-        "mime",
-        "promises",
-        "rlang",
-        "sourcetools",
-        "tools",
-        "utils",
-        "withr",
-        "xtable"
-      ],
-      "Hash": "6a293995a66e12c48d13aa1f957d09c7"
-    },
-    "sourcetools": {
-      "Package": "sourcetools",
-      "Version": "0.1.7-1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "5f5a7629f956619d519205ec475fe647"
-    },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.8.3",
+      "Version": "1.8.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "stats",
         "tools",
         "utils"
       ],
-      "Hash": "058aebddea264f4c99401515182e656a"
+      "Hash": "39e1144fd75428983dc3f63aa53dfa91"
     },
     "stringr": {
       "Package": "stringr",
       "Version": "1.5.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -792,7 +665,7 @@
       "Package": "tibble",
       "Version": "3.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "fansi",
@@ -809,9 +682,9 @@
     },
     "tidyr": {
       "Package": "tidyr",
-      "Version": "1.3.0",
+      "Version": "1.3.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -828,13 +701,13 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "e47debdc7ce599b070c8e78e8ac0cfcf"
+      "Hash": "915fb7ce036c22a6a33b5a8adb712eb1"
     },
     "tidyselect": {
       "Package": "tidyselect",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -844,23 +717,23 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "79540e5fcd9e0435af547d885f184fd5"
+      "Hash": "829f27b9c4919c16b593794a6344d6c0"
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.53",
+      "Version": "0.54",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "9db859e8aabbb474293dde3097839420"
+      "Hash": "3ec7e3ddcacc2d34a9046941222bf94d"
     },
     "utf8": {
       "Package": "utf8",
       "Version": "1.2.4",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -870,7 +743,7 @@
       "Package": "vctrs",
       "Version": "0.6.5",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
@@ -884,7 +757,7 @@
       "Package": "viridisLite",
       "Version": "0.4.2",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
@@ -892,46 +765,35 @@
     },
     "withr": {
       "Package": "withr",
-      "Version": "2.5.2",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "stats"
-      ],
-      "Hash": "4b25e70111b7d644322e9513f403a272"
-    },
-    "xfun": {
-      "Package": "xfun",
-      "Version": "0.41",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "stats",
-        "tools"
-      ],
-      "Hash": "460a5e0fe46a80ef87424ad216028014"
-    },
-    "xtable": {
-      "Package": "xtable",
-      "Version": "1.8-4",
+      "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
-        "stats",
-        "utils"
+        "grDevices",
+        "graphics"
       ],
-      "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
+      "Hash": "cc2d62c76458d425210d1eb1478b30b4"
+    },
+    "xfun": {
+      "Package": "xfun",
+      "Version": "0.49",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "stats",
+        "tools"
+      ],
+      "Hash": "8687398773806cfff9401a2feca96298"
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.3.8",
+      "Version": "2.3.10",
       "Source": "Repository",
-      "Repository": "RSPM",
-      "Hash": "29240487a071f535f5e5d5a323b7afbd"
+      "Repository": "CRAN",
+      "Hash": "51dab85c6c98e50a18d7551e9d49f76c"
     }
   }
 }

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,11 +2,13 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.3"
+  version <- "1.0.7"
   attr(version, "sha") <- NULL
 
   # the project directory
-  project <- getwd()
+  project <- Sys.getenv("RENV_PROJECT")
+  if (!nzchar(project))
+    project <- getwd()
 
   # use start-up diagnostics if enabled
   diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")
@@ -31,6 +33,14 @@ local({
     if (!is.null(override))
       return(override)
 
+    # if we're being run in a context where R_LIBS is already set,
+    # don't load -- presumably we're being run as a sub-process and
+    # the parent process has already set up library paths for us
+    rcmd <- Sys.getenv("R_CMD", unset = NA)
+    rlibs <- Sys.getenv("R_LIBS", unset = NA)
+    if (!is.na(rlibs) && !is.na(rcmd))
+      return(FALSE)
+
     # next, check environment variables
     # TODO: prefer using the configuration one in the future
     envvars <- c(
@@ -50,8 +60,21 @@ local({
 
   })
 
-  if (!enabled)
+  # bail if we're not enabled
+  if (!enabled) {
+
+    # if we're not enabled, we might still need to manually load
+    # the user profile here
+    profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
+    if (file.exists(profile)) {
+      cfg <- Sys.getenv("RENV_CONFIG_USER_PROFILE", unset = "TRUE")
+      if (tolower(cfg) %in% c("true", "t", "1"))
+        sys.source(profile, envir = globalenv())
+    }
+
     return(FALSE)
+
+  }
 
   # avoid recursion
   if (identical(getOption("renv.autoloader.running"), TRUE)) {
@@ -105,6 +128,21 @@ local({
   
     tail <- paste(rep.int(suffix, n), collapse = "")
     paste0(prefix, " ", label, " ", tail)
+  
+  }
+  
+  heredoc <- function(text, leave = 0) {
+  
+    # remove leading, trailing whitespace
+    trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
+  
+    # split into lines
+    lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
+  
+    # compute common indent
+    indent <- regexpr("[^[:space:]]", lines)
+    common <- min(setdiff(indent, -1L)) - leave
+    paste(substring(lines, common), collapse = "\n")
   
   }
   
@@ -610,6 +648,9 @@ local({
   
     # if the user has requested an automatic prefix, generate it
     auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (is.na(auto) && getRversion() >= "4.4.0")
+      auto <- "TRUE"
+  
     if (auto %in% c("TRUE", "True", "true", "1"))
       return(renv_bootstrap_platform_prefix_auto())
   
@@ -801,24 +842,23 @@ local({
   
     # the loaded version of renv doesn't match the requested version;
     # give the user instructions on how to proceed
-    remote <- if (!is.null(description[["RemoteSha"]])) {
+    dev <- identical(description[["RemoteType"]], "github")
+    remote <- if (dev)
       paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
-    } else {
+    else
       paste("renv", description[["Version"]], sep = "@")
-    }
   
     # display both loaded version + sha if available
     friendly <- renv_bootstrap_version_friendly(
       version = description[["Version"]],
-      sha     = description[["RemoteSha"]]
+      sha     = if (dev) description[["RemoteSha"]]
     )
   
-    fmt <- paste(
-      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
-      "- Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
-      "- Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
-      sep = "\n"
-    )
+    fmt <- heredoc("
+      renv %1$s was loaded from project library, but this project is configured to use renv %2$s.
+      - Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.
+      - Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.
+    ")
     catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
   
     FALSE
@@ -1041,7 +1081,7 @@ local({
     # if jsonlite is loaded, use that instead
     if ("jsonlite" %in% loadedNamespaces()) {
   
-      json <- catch(renv_json_read_jsonlite(file, text))
+      json <- tryCatch(renv_json_read_jsonlite(file, text), error = identity)
       if (!inherits(json, "error"))
         return(json)
   
@@ -1050,7 +1090,7 @@ local({
     }
   
     # otherwise, fall back to the default JSON reader
-    json <- catch(renv_json_read_default(file, text))
+    json <- tryCatch(renv_json_read_default(file, text), error = identity)
     if (!inherits(json, "error"))
       return(json)
   
@@ -1063,14 +1103,14 @@ local({
   }
   
   renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
-    text <- paste(text %||% read(file), collapse = "\n")
+    text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
   }
   
   renv_json_read_default <- function(file = NULL, text = NULL) {
   
     # find strings in the JSON
-    text <- paste(text %||% read(file), collapse = "\n")
+    text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
   
@@ -1118,14 +1158,14 @@ local({
     map <- as.list(map)
   
     # remap strings in object
-    remapped <- renv_json_remap(json, map)
+    remapped <- renv_json_read_remap(json, map)
   
     # evaluate
     eval(remapped, envir = baseenv())
   
   }
   
-  renv_json_remap <- function(json, map) {
+  renv_json_read_remap <- function(json, map) {
   
     # fix names
     if (!is.null(names(json))) {
@@ -1152,7 +1192,7 @@ local({
     # recurse
     if (is.recursive(json)) {
       for (i in seq_along(json)) {
-        json[i] <- list(renv_json_remap(json[[i]], map))
+        json[i] <- list(renv_json_read_remap(json[[i]], map))
       }
     }
   

--- a/report.Rmd
+++ b/report.Rmd
@@ -19,11 +19,13 @@ proj_data <- readRDS(
 
 
 # Descriptive Analysis
-
-
 ```{r, demographics, echo=FALSE}
+# Note for Neil: I've added a prototype for variable name and function structure below, so that we can keep a consistent format <remove this line when you've read it>
+table_demographics <- readRDS(
+  file = here::here("output/table_demographics.rds")
+)
 
-
+knitr::kable(table_demographics, caption="") # Add Caption here and delete this comment
 ```
 
 
@@ -40,7 +42,6 @@ knitr::kable(table_resp, caption="Frequencies of Respiratory Diseases Cases by C
 knitr::include_graphics(
   here::here("output/resp_fig.png")
 )
-
 ```
 
 
@@ -49,8 +50,9 @@ table_nonresp <- readRDS(
   file = here::here("output/table_nonresp.rds")
 )
 
-table_nonresp
+knitr::kable(table_nonresp, caption="Frequencies of Non-Respiratory Diseases Cases by Covid-19 Status")
 
+# Show Figure
 #| fig.align = "center",
 #| out.width = "600px"
 knitr::include_graphics(
@@ -58,13 +60,15 @@ knitr::include_graphics(
 )
 ```
 
+
 ```{r, severity, echo = FALSE, eval = params$severe}
 table_severity <- readRDS(
   file = here::here("output/table_severity.rds")
 )
 
-table_severity
+knitr::kable(table_severity, caption="Frequencies of Disease Severity by Covid-19 Status")
 
+# Show Figure
 #| fig.align = "center",
 #| out.width = "600px"
 knitr::include_graphics(


### PR DESCRIPTION
Hi Neha,

I made the following change:

1. Standardized the apperance of all the tables, graphs and report.rmd to:
 - Simiar title
 - same type of comments in code
 - removed all the "_" in the variable name in the report
 - same theme (all to default theme)
 - same method of loading tables (knitr::kable) and figures (knitr::include_graphics)

2. Added a prototype code and some comments for Neil's part (just the demographics table, right?) so that he can follow the standard above.

3. Modified the makefile for Neil's table.
4. Added some instruction of using renv and rendering report in the README file.
5. Last but not least ——
I deleted the renv.lock file and redo renv::snapshot() to recreate it, because I had problem doing renv::restore for a couple of packages, such as Rcpp etc. The error was something like `Rcpp compilation failed because of g++ version`, which is a speghetti issue and had taken me too long to resolve, I didn't think I could resolve it in short. So I finally decided to recreate the renv.lock file.
This means you may need to do the renv::restore at your end, thanks for your understanding

Best, Leshan